### PR TITLE
feat: 添加对 crypto-js 的支持以增强密码加密功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "axios": "^1.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "crypto-js": "^4.2.0",
     "embla-carousel-vue": "^8.6.0",
     "lodash-es": "^4.17.21",
     "lucide-vue-next": "^0.539.0",
@@ -28,6 +29,7 @@
     "vuedraggable": "^4.1.0"
   },
   "devDependencies": {
+    "@types/crypto-js": "^4.2.2",
     "@types/node": "^24.2.1",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vue/tsconfig": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      crypto-js:
+        specifier: ^4.2.0
+        version: 4.2.0
       embla-carousel-vue:
         specifier: ^8.6.0
         version: 8.6.0(vue@3.5.18(typescript@5.8.3))
@@ -60,6 +63,9 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(vue@3.5.18(typescript@5.8.3))
     devDependencies:
+      '@types/crypto-js':
+        specifier: ^4.2.2
+        version: 4.2.2
       '@types/node':
         specifier: ^24.2.1
         version: 24.2.1
@@ -522,6 +528,9 @@ packages:
     peerDependencies:
       vue: ^2.7.0 || ^3.0.0
 
+  '@types/crypto-js@4.2.2':
+    resolution: {integrity: sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -660,6 +669,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -1349,6 +1361,8 @@ snapshots:
       '@tanstack/virtual-core': 3.13.12
       vue: 3.5.18(typescript@5.8.3)
 
+  '@types/crypto-js@4.2.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/lodash-es@4.17.12':
@@ -1522,6 +1536,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  crypto-js@4.2.0: {}
 
   csstype@3.1.3: {}
 

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -1,3 +1,4 @@
+import CryptoJS from 'crypto-js'
 /**
  * 密码加密工具类
  * 使用SHA-256进行密码哈希加密
@@ -6,9 +7,9 @@
 /**
  * 将字符串转换为Uint8Array
  */
-function stringToUint8Array(str: string): Uint8Array {
+function stringToArrayBuffer(str: string): ArrayBuffer {
   const encoder = new TextEncoder()
-  return encoder.encode(str)
+  return encoder.encode(str).buffer
 }
 
 /**
@@ -31,14 +32,18 @@ function arrayBufferToHex(buffer: ArrayBuffer): string {
  */
 export async function encryptPassword(password: string): Promise<string> {
   try {
-    // 将密码转换为Uint8Array
-    const data = stringToUint8Array(password)
-    
-    // 使用Web Crypto API的SHA-256算法进行哈希
-    const hashBuffer = await crypto.subtle.digest('SHA-256', data)
-    
-    // 将哈希结果转换为十六进制字符串
-    return arrayBufferToHex(hashBuffer)
+    // 判断是否为安全上下文且 crypto.subtle 可用
+    if (window.isSecureContext && window.crypto?.subtle) {
+      // 将密码转换为Uint8Array
+  const data = stringToArrayBuffer(password)
+      // 使用Web Crypto API的SHA-256算法进行哈希
+      const hashBuffer = await crypto.subtle.digest('SHA-256', data)
+      // 将哈希结果转换为十六进制字符串
+      return arrayBufferToHex(hashBuffer)
+    } else {
+      // 非安全环境，使用 crypto-js
+      return CryptoJS.SHA256(password).toString()
+    }
   } catch (error) {
     console.error('密码加密失败:', error)
     throw new Error('密码加密失败')


### PR DESCRIPTION
This pull request adds support for password encryption using SHA-256, with automatic fallback between the browser's native Web Crypto API and the new `crypto-js` library for environments where the native API isn't available. It also updates dependencies to include `crypto-js` and its TypeScript types.

**Dependency updates:**

* Added `crypto-js` to `dependencies` in `package.json` and `pnpm-lock.yaml`, enabling cryptographic operations in non-secure contexts. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R19) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR32-R34) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR673-R675) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1540-R1541)
* Added `@types/crypto-js` to `devDependencies` in `package.json` and `pnpm-lock.yaml` for TypeScript support. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R32) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR66-R68) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR531-R533) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1364-R1365)

**Crypto utility improvements:**

* Updated `src/lib/crypto.ts` to use the browser's Web Crypto API for password hashing when available, and fallback to `crypto-js` otherwise. This ensures consistent encryption across different environments. [[1]](diffhunk://#diff-39cc60a3e475f3acd7f4164c1409d67550258acb87b9e288cad1a5dc0c226aecR1) [[2]](diffhunk://#diff-39cc60a3e475f3acd7f4164c1409d67550258acb87b9e288cad1a5dc0c226aecR35-R46)
* Refactored the string conversion function to return an `ArrayBuffer` instead of a `Uint8Array`, aligning with Web Crypto API requirements.