### PR TITLE
fix: 优化空间信息加载逻辑，添加默认值处理和加载状态指示

### DIFF
--- a/src/components/Sidebar/NavTag.vue
+++ b/src/components/Sidebar/NavTag.vue
@@ -331,10 +331,6 @@ onUnmounted(() => {
               <Folder class="text-muted-foreground"/>
               <span>修改标签</span>
             </DropdownMenuItem>
-            <DropdownMenuItem>
-              <Forward class="text-muted-foreground"/>
-              <span>分享标签</span>
-            </DropdownMenuItem>
             <DropdownMenuSeparator/>
             <DropdownMenuItem @click="confirmDeleteTag(item)">
               <Trash2 class="text-muted-foreground"/>


### PR DESCRIPTION
#5 
This pull request improves the user experience and error handling in the dashboard's space view, especially when loading space information. The changes ensure more robust handling of API responses, clearer loading states, and better fallback messaging when space data cannot be retrieved. Additionally, a minor UI cleanup is made in the sidebar tag menu.

**Space Info Loading & Error Handling Improvements:**

* Added an `isLoadingSpace` state to control loading indicators and fallback messaging for space information, ensuring users see "加载中..." or "未知空间" as appropriate. (`src/pages/dashboard/views/Space.vue`) [[1]](diffhunk://#diff-4d63369864a894ed1c86c657252b2e9a5fa931fb172cf9404e60421de2985fecL13-R13) [[2]](diffhunk://#diff-4d63369864a894ed1c86c657252b2e9a5fa931fb172cf9404e60421de2985fecR243)
* Enhanced `fetchSpaceInfo` to check for both `code === 0` and `flag === true` for successful API responses, added debug logs, and provided a default value for `currentSpace` on failure to avoid indefinite loading states. (`src/pages/dashboard/views/Space.vue`)

**Data Refresh Logic:**

* Updated the watcher on `spaceId` to clear old data and load new space and bookmark data in parallel only when the space ID changes, improving responsiveness and data consistency. (`src/pages/dashboard/views/Space.vue`)

**UI Cleanup:**

* Removed the "分享标签" (Share Tag) option from the sidebar tag dropdown menu for a cleaner UI. (`src/components/Sidebar/NavTag.vue`)